### PR TITLE
Tagging

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -17,6 +17,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer', platforms: :ruby
+gem 'acts-as-taggable-on'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -17,7 +17,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer', platforms: :ruby
-gem 'acts-as-taggable-on'
+gem 'acts-as-taggable-on', '~> 5.0'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (5.0.0)
+      activerecord (>= 4.2.8)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     archive-zip (0.11.0)
@@ -239,6 +241,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15, < 4.0)

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -241,7 +241,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  acts-as-taggable-on
+  acts-as-taggable-on (~> 5.0)
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15, < 4.0)

--- a/rails/app/models/point.rb
+++ b/rails/app/models/point.rb
@@ -1,3 +1,4 @@
 class Point < ApplicationRecord
   has_many :stories
+  acts_as_taggable
 end

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -1,5 +1,5 @@
 class Story < ApplicationRecord
   has_many :medium
   belongs_to :point
-  acts_as_taggable_on :categories
+  acts_as_taggable
 end

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -1,4 +1,5 @@
 class Story < ApplicationRecord
   has_many :medium
   belongs_to :point
+  acts_as_taggable_on :categories
 end

--- a/rails/db/migrate/20180608234834_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/rails/db/migrate/20180608234834_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,36 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/rails/db/migrate/20180608234835_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/rails/db/migrate/20180608234835_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/rails/db/migrate/20180608234836_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/rails/db/migrate/20180608234836_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/rails/db/migrate/20180608234837_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/rails/db/migrate/20180608234837_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/rails/db/migrate/20180608234838_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/rails/db/migrate/20180608234838_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/rails/db/migrate/20180608234839_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/rails/db/migrate/20180608234839_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
+
+    unless index_exists? :taggings, [:tagger_id, :tagger_type]
+      add_index :taggings, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/rails/db/migrate/20180609005433_add_point_id_to_story.rb
+++ b/rails/db/migrate/20180609005433_add_point_id_to_story.rb
@@ -1,0 +1,5 @@
+class AddPointIdToStory < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stories, :point_id, :string
+  end
+end

--- a/rails/db/migrate/20180609005433_add_point_id_to_story.rb
+++ b/rails/db/migrate/20180609005433_add_point_id_to_story.rb
@@ -1,5 +1,5 @@
 class AddPointIdToStory < ActiveRecord::Migration[5.2]
   def change
-    add_column :stories, :point_id, :string
+    add_column :stories, :point_id, :integer
   end
 end

--- a/rails/db/migrate/20180609153434_remove_story_and_location_type_from_point.rb
+++ b/rails/db/migrate/20180609153434_remove_story_and_location_type_from_point.rb
@@ -1,0 +1,6 @@
+class RemoveStoryAndLocationTypeFromPoint < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :points, :story, :string
+    remove_column :points, :location_type, :string
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_09_005433) do
+ActiveRecord::Schema.define(version: 2018_06_09_153434) do
 
   create_table "media", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "story_id"
@@ -24,10 +24,8 @@ ActiveRecord::Schema.define(version: 2018_06_09_005433) do
 
   create_table "points", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
-    t.string "story"
     t.decimal "lng", precision: 10
     t.decimal "lat", precision: 10
-    t.string "location_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -47,7 +45,7 @@ ActiveRecord::Schema.define(version: 2018_06_09_005433) do
     t.string "speaker"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "point_id"
+    t.integer "point_id"
   end
 
   create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_09_151942) do
-
+ActiveRecord::Schema.define(version: 2018_06_08_234839) do
   create_table "media", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "story_id"
     t.string "media_type"
@@ -47,6 +46,31 @@ ActiveRecord::Schema.define(version: 2018_06_09_151942) do
     t.string "speaker"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", collation: "utf8_bin"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_08_234839) do
+ActiveRecord::Schema.define(version: 2018_06_09_005433) do
+
   create_table "media", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "story_id"
     t.string "media_type"
@@ -46,6 +47,7 @@ ActiveRecord::Schema.define(version: 2018_06_08_234839) do
     t.string "speaker"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "point_id"
   end
 
   create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
Resolves #15 

Adds the `ActsAsTaggableOn` gem and allows for tags on both Point and Story models. Also adds a `point_id` column to the stories table to complete the relationship between the two.

These migrations also remove some string columns that will be replaced by tags, which are their own model provided by the gem.