### PR TITLE
Configure docker to use data directory for local db persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,5 @@ bower.json
 # Ignore node_modules
 node_modules/
 
+# Ignore editor and IDE files
 .idea/

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,16 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
     networks:
       - railroad
+    volumes:
+      - ./data:/bitnami/mariadb/data
 
   nginx:
-    #command: /bin/bash -c "sed s@NGINX_PORT@$NGINX_PORT@ /etc/nginx/nginx.conf > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
+    # This command is a bit of hack for getting the local NGINX_PORT value
+    # into ngingx.conf. It uses sed for string replacement, which is altered
+    # by docker-compose first substituting the shell var $NGINX_PORT into the
+    # substitution string. Then, the resulting subsitution from the template
+    # file is copied to the real nginx.conf file before the normal nginx start
+    # command is given.
     command: /bin/bash -c "sed s@NGINX_PORT@$NGINX_PORT@ /etc/nginx/nginx-template.conf > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
     depends_on:
       - rails


### PR DESCRIPTION
Resolves #30 

This repo now contains an empty `data` directory with a `.gitignore` that should ensure nothing in it is ever checked in. The docker-compose.yml has been updated to use that directory to persist data from the mariadb container. This should allow for easy backup and transfer of database data from the local environment without polluting the repo.