### PR TITLE
[88][86] Add permission level to stories, role to users, add policy for viewing Stories, and clean up administrate dashboards

### DIFF
--- a/rails/app/controllers/admin/application_controller.rb
+++ b/rails/app/controllers/admin/application_controller.rb
@@ -6,10 +6,11 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
+    before_action :authenticate_user!
     before_action :authenticate_admin
 
     def authenticate_admin
-      # TODO Add authentication logic here.
+      redirect_to '/', alert: 'Not authorized.' unless current_user && current_user.editor?
     end
 
     # Override this value to specify the number of elements to display at a time

--- a/rails/app/controllers/admin/users_controller.rb
+++ b/rails/app/controllers/admin/users_controller.rb
@@ -17,5 +17,15 @@ module Admin
 
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information
+
+
+    def update
+      if params[:user][:password].blank?
+        params[:user].delete(:password)
+        params[:user].delete(:password_confirmation)
+      end
+      super
+    end
+
   end
 end

--- a/rails/app/controllers/home_controller.rb
+++ b/rails/app/controllers/home_controller.rb
@@ -13,7 +13,6 @@ class HomeController < ApplicationController
   end
 
   helper_method def stories
-    Story.all.includes(:point, :media_attachments)
-    # [Story.new(title: 'Story Title', desc: 'Description')] * 4
+    policy_scope(Story)
   end
 end

--- a/rails/app/controllers/registrations_controller.rb
+++ b/rails/app/controllers/registrations_controller.rb
@@ -1,0 +1,12 @@
+class RegistrationsController < Devise::RegistrationsController
+
+    private
+  
+    def sign_up_params
+      params.require(:user).permit(:email, :role, :password, :password_confirmation)
+    end
+  
+    def account_update_params
+      params.require(:user).permit(:email, :role, :password, :password_confirmation, :current_password)
+    end
+  end

--- a/rails/app/dashboards/point_dashboard.rb
+++ b/rails/app/dashboards/point_dashboard.rb
@@ -9,9 +9,6 @@ class PointDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     stories: Field::HasMany,
-    taggings: Field::HasMany.with_options(class_name: "::ActsAsTaggableOn::Tagging"),
-    base_tags: Field::HasMany.with_options(class_name: "::ActsAsTaggableOn::Tag"),
-    tag_taggings: Field::HasMany.with_options(class_name: "ActsAsTaggableOn::Tagging"),
     tags: Field::HasMany.with_options(class_name: "ActsAsTaggableOn::Tag"),
     id: Field::Number,
     title: Field::String,
@@ -28,10 +25,12 @@ class PointDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
-    :stories,
-    :taggings,
-    :base_tags,
-    :tag_taggings,
+    :id,
+    :title,
+    :lng,
+    :lat,
+    :region,
+    :stories
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -56,10 +55,6 @@ class PointDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :stories,
-    :taggings,
-    :base_tags,
-    :tag_taggings,
-    :tags,
     :title,
     :lng,
     :lat,

--- a/rails/app/dashboards/speaker_dashboard.rb
+++ b/rails/app/dashboards/speaker_dashboard.rb
@@ -8,13 +8,11 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    stories: Field::HasMany,
-    media: Field::ActiveStorage,
     id: Field::Number,
     name: Field::String,
-    photo: Field::String,
     region: Field::String,
     community: Field::String,
+    stories: Field::HasMany,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -25,21 +23,21 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
-    :stories,
-    :media,
     :id,
+    :name,
+    :region,
+    :community
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
-    :stories,
-    :media,
     :id,
     :name,
     :photo,
     :region,
     :community,
+    :stories,
     :created_at,
     :updated_at,
   ].freeze
@@ -48,12 +46,11 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :stories,
-    :media,
     :name,
     :photo,
     :region,
     :community,
+    :stories
   ].freeze
 
   # Overwrite this method to customize how speakers are displayed

--- a/rails/app/dashboards/speaker_dashboard.rb
+++ b/rails/app/dashboards/speaker_dashboard.rb
@@ -9,6 +9,7 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
+    media: Field::ActiveStorage,
     name: Field::String,
     region: Field::String,
     community: Field::String,
@@ -24,6 +25,7 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
     :id,
+    :media,
     :name,
     :region,
     :community
@@ -33,6 +35,7 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
     :id,
+    :media,
     :name,
     :region,
     :community,
@@ -45,6 +48,7 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
+    :media,
     :name,
     :region,
     :community,
@@ -57,4 +61,8 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # def display_resource(speaker)
   #   "Speaker ##{speaker.id}"
   # end
+
+  def permitted_attributes
+    super + [media: [], permission_level: [:anonymous, :user_only, :editor_only]]
+  end
 end

--- a/rails/app/dashboards/speaker_dashboard.rb
+++ b/rails/app/dashboards/speaker_dashboard.rb
@@ -34,7 +34,6 @@ class SpeakerDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = [
     :id,
     :name,
-    :photo,
     :region,
     :community,
     :stories,
@@ -47,7 +46,6 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :name,
-    :photo,
     :region,
     :community,
     :stories

--- a/rails/app/dashboards/story_dashboard.rb
+++ b/rails/app/dashboards/story_dashboard.rb
@@ -13,9 +13,8 @@ class StoryDashboard < Administrate::BaseDashboard
     desc: Field::Text,
     speaker: Field::BelongsTo,
     point: Field::BelongsTo,
-    permission_level: EnumField.with_options(
-      choices: [:anonymous, :user_only, :editor_only]
-    ),
+    media: Field::ActiveStorage,
+    permission_level: EnumField,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -31,6 +30,7 @@ class StoryDashboard < Administrate::BaseDashboard
     :desc,
     :speaker,
     :point,
+    :media,
     :permission_level
   ].freeze
 
@@ -42,6 +42,7 @@ class StoryDashboard < Administrate::BaseDashboard
     :desc,
     :speaker,
     :point,
+    :media,
     :permission_level,
     :created_at,
     :updated_at,
@@ -55,6 +56,7 @@ class StoryDashboard < Administrate::BaseDashboard
     :desc,
     :speaker,
     :point,
+    :media,
     :permission_level
   ].freeze
 
@@ -66,6 +68,6 @@ class StoryDashboard < Administrate::BaseDashboard
   # end
 
   def permitted_attributes
-    super + [media: []]
+    super + [media: [], permission_level: [:anonymous, :user_only, :editor_only]]
   end
 end

--- a/rails/app/dashboards/story_dashboard.rb
+++ b/rails/app/dashboards/story_dashboard.rb
@@ -8,13 +8,14 @@ class StoryDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    point: Field::BelongsTo,
-    speaker: Field::BelongsTo,
-    media: Field::ActiveStorage,
-    tag_list: Field::String,
     id: Field::Number,
     title: Field::String,
     desc: Field::Text,
+    speaker: Field::BelongsTo,
+    point: Field::BelongsTo,
+    permission_level: EnumField.with_options(
+      choices: [:anonymous, :user_only, :editor_only]
+    ),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -25,21 +26,23 @@ class StoryDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
-    :point,
+    :id, 
+    :title,
+    :desc,
     :speaker,
-    :media,
+    :point,
+    :permission_level
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
-    :point,
-    :speaker,
-    :media,
-    :tag_list,
     :id,
     :title,
     :desc,
+    :speaker,
+    :point,
+    :permission_level,
     :created_at,
     :updated_at,
   ].freeze
@@ -48,12 +51,11 @@ class StoryDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :point,
-    :speaker,
-    :media,
-    :tag_list,
     :title,
     :desc,
+    :speaker,
+    :point,
+    :permission_level
   ].freeze
 
   # Overwrite this method to customize how stories are displayed

--- a/rails/app/dashboards/user_dashboard.rb
+++ b/rails/app/dashboards/user_dashboard.rb
@@ -10,9 +10,8 @@ class UserDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     email: Field::String,
-    role: EnumField.with_options(
-      choices: [:user, :editor]
-    ),
+    role: EnumField,
+    password: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -33,6 +32,7 @@ class UserDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = [
     :id,
     :email,
+    :password,
     :role,
     :created_at,
     :updated_at,
@@ -43,6 +43,7 @@ class UserDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :email,
+    :password,
     :role
   ].freeze
 

--- a/rails/app/dashboards/user_dashboard.rb
+++ b/rails/app/dashboards/user_dashboard.rb
@@ -10,15 +10,9 @@ class UserDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     email: Field::String,
-    encrypted_password: Field::String,
-    reset_password_token: Field::String,
-    reset_password_sent_at: Field::DateTime,
-    remember_created_at: Field::DateTime,
-    sign_in_count: Field::Number,
-    current_sign_in_at: Field::DateTime,
-    last_sign_in_at: Field::DateTime,
-    current_sign_in_ip: Field::String,
-    last_sign_in_ip: Field::String,
+    role: EnumField.with_options(
+      choices: [:user, :editor]
+    ),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -31,8 +25,7 @@ class UserDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = [
     :id,
     :email,
-    :encrypted_password,
-    :reset_password_token,
+    :role
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -40,15 +33,7 @@ class UserDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = [
     :id,
     :email,
-    :encrypted_password,
-    :reset_password_token,
-    :reset_password_sent_at,
-    :remember_created_at,
-    :sign_in_count,
-    :current_sign_in_at,
-    :last_sign_in_at,
-    :current_sign_in_ip,
-    :last_sign_in_ip,
+    :role,
     :created_at,
     :updated_at,
   ].freeze
@@ -58,15 +43,7 @@ class UserDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :email,
-    :encrypted_password,
-    :reset_password_token,
-    :reset_password_sent_at,
-    :remember_created_at,
-    :sign_in_count,
-    :current_sign_in_at,
-    :last_sign_in_at,
-    :current_sign_in_ip,
-    :last_sign_in_ip,
+    :role
   ].freeze
 
   # Overwrite this method to customize how users are displayed

--- a/rails/app/fields/enum_field.rb
+++ b/rails/app/fields/enum_field.rb
@@ -1,0 +1,13 @@
+require "administrate/field/base"
+
+class EnumField < Administrate::Field::Base
+  def to_s
+    data
+  end
+
+  def select_field_values(form_builder)
+    form_builder.object.class.public_send(attribute.to_s.pluralize).keys.map do |v|
+      [v.titleize, v]
+    end
+  end
+end

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -5,6 +5,5 @@ class Story < ApplicationRecord
 
   acts_as_taggable
 
-  PERMISSION_LEVEL = ['anonymous', 'user', 'editor']
-  validates_inclusion_of :permission_level, :in => PERMISSION_LEVEL
+  enum permission_level: [:anonymous, :user_only, :editor_only]
 end

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -5,4 +5,6 @@ class Story < ApplicationRecord
 
   acts_as_taggable
 
+  PERMISSION_LEVEL = ['anonymous', 'user', 'editor']
+  validates_inclusion_of :permission_level, :in => PERMISSION_LEVEL
 end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -3,4 +3,11 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  enum role: [:user, :editor]
+  
+  after_initialize :set_default_role, :if => :new_record?
+
+  def set_default_role
+    self.role ||= :user
+  end
 end

--- a/rails/app/policies/story_policy.rb
+++ b/rails/app/policies/story_policy.rb
@@ -1,18 +1,21 @@
 class StoryPolicy
-    attr_reader :user, :story
+    class Scope
+        attr_reader :user, :story
 
-    def initialize(user, story)
-        @user = user
-        @story = story
-    end
+        def initialize(user, story)
+            @user = user
+            @story = story
+        end
 
-    def update?
-        user.editor?
-    end
-
-    def resolve
-        stories = Story.all
-        stories.reject! { |story| story.PERMISSION_LEVEL == 'editor' } unless user.editor?
-        stories
+        def resolve
+            stories = Story.where(permission_level: :anonymous)
+            if user.present?
+                stories = Story.where(permission_level: [:anonymous, :user_only])
+            end
+            if user && user.editor?
+                stories = Story.all
+            end
+            stories
+        end
     end
 end

--- a/rails/app/policies/story_policy.rb
+++ b/rails/app/policies/story_policy.rb
@@ -1,0 +1,18 @@
+class StoryPolicy
+    attr_reader :user, :story
+
+    def initialize(user, story)
+        @user = user
+        @story = story
+    end
+
+    def update?
+        user.editor?
+    end
+
+    def resolve
+        stories = Story.all
+        stories.reject! { |story| story.PERMISSION_LEVEL == 'editor' } unless user.editor?
+        stories
+    end
+end

--- a/rails/app/views/fields/enum_field/_form.html.erb
+++ b/rails/app/views/fields/enum_field/_form.html.erb
@@ -1,0 +1,6 @@
+<div class="field-unit__label">
+  <%= f.label field.attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.select field.attribute, field.select_field_values(f) %>
+</div>

--- a/rails/app/views/fields/enum_field/_index.html.erb
+++ b/rails/app/views/fields/enum_field/_index.html.erb
@@ -1,1 +1,1 @@
-<%= field.to_s.titleize if field.to_s %>
+<%= field.to_s.titleize %>

--- a/rails/app/views/fields/enum_field/_index.html.erb
+++ b/rails/app/views/fields/enum_field/_index.html.erb
@@ -1,0 +1,1 @@
+<%= field.to_s.titleize if field.to_s %>

--- a/rails/app/views/fields/enum_field/_show.html.erb
+++ b/rails/app/views/fields/enum_field/_show.html.erb
@@ -1,1 +1,1 @@
-<%= field.to_s.titleize if field.to_s %>
+<%= field.to_s.titleize %>

--- a/rails/app/views/fields/enum_field/_show.html.erb
+++ b/rails/app/views/fields/enum_field/_show.html.erb
@@ -1,0 +1,1 @@
+<%= field.to_s.titleize if field.to_s %>

--- a/rails/app/views/welcome/index.html.erb
+++ b/rails/app/views/welcome/index.html.erb
@@ -9,8 +9,13 @@
 
     <h4 class="l--75">Are you an Admin?</h4>
 
-    <%= button_tag(type: 'button', class: "l--75 inverse") do %>
-      <% link_to "Sign In", new_user_session_path %>
+    <% if user_signed_in? %>
+      Logged in as <strong><%= current_user.email %></strong>.
+      <%= link_to 'Edit profile', edit_user_registration_path, :class => 'navbar-link' %> |
+      <%= link_to "Logout", destroy_user_session_path, method: :delete, :class => 'navbar-link'  %>
+    <% else %>
+      <%= link_to "Sign up", new_user_registration_path, :class => 'navbar-link'  %> |
+      <%= link_to "Login", new_user_session_path, :class => 'navbar-link'  %>
     <% end %>
   </div>
 </div>

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
       root to: "users#index"
     end
   resources :stories
-  devise_for :users
+  devise_for :users, :controllers => { registrations: 'registrations' }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'welcome#index'
   get 'home', to: 'home#index', as: "home_map"

--- a/rails/db/migrate/20180909233303_add_role_to_users.rb
+++ b/rails/db/migrate/20180909233303_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :integer
+  end
+end

--- a/rails/db/migrate/20180909234528_add_access_to_stories.rb
+++ b/rails/db/migrate/20180909234528_add_access_to_stories.rb
@@ -1,5 +1,5 @@
 class AddAccessToStories < ActiveRecord::Migration[5.2]
   def change
-    add_column :stories, :permission_level, :string
+    add_column :stories, :permission_level, :integer
   end
 end

--- a/rails/db/migrate/20180909234528_add_access_to_stories.rb
+++ b/rails/db/migrate/20180909234528_add_access_to_stories.rb
@@ -1,0 +1,5 @@
+class AddAccessToStories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stories, :permission_level, :string
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -33,16 +33,6 @@ ActiveRecord::Schema.define(version: 2018_09_09_234528) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "media", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "story_id"
-    t.string "media_type"
-    t.string "description"
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["story_id"], name: "index_media_on_story_id"
-  end
-
   create_table "points", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.decimal "lng", precision: 15, scale: 13
@@ -115,7 +105,7 @@ ActiveRecord::Schema.define(version: 2018_09_09_234528) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-  add_foreign_key "media", "stories"
+
   add_foreign_key "stories", "points"
   add_foreign_key "stories", "speakers"
 end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_10_154604) do
+ActiveRecord::Schema.define(version: 2018_09_09_234528) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2018_06_10_154604) do
     t.datetime "updated_at", null: false
     t.bigint "speaker_id"
     t.bigint "point_id"
+    t.string "permission_level"
     t.index ["point_id"], name: "index_stories_on_point_id"
     t.index ["speaker_id"], name: "index_stories_on_speaker_id"
   end
@@ -110,10 +111,10 @@ ActiveRecord::Schema.define(version: 2018_06_10_154604) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
   add_foreign_key "media", "stories"
   add_foreign_key "stories", "points"
   add_foreign_key "stories", "speakers"

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2018_09_09_234528) do
     t.datetime "updated_at", null: false
     t.bigint "speaker_id"
     t.bigint "point_id"
-    t.string "permission_level"
+    t.integer "permission_level"
     t.index ["point_id"], name: "index_stories_on_point_id"
     t.index ["speaker_id"], name: "index_stories_on_speaker_id"
   end

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -41,3 +41,7 @@ Story.create(title: "Fa di Kwinti nengeb bi feti ku Matawai sembe",
              speaker: Speaker.first,
              point: Point.fourth,
              permission_level: 1)
+
+User.create(email: 'admin@terrastories.com',
+            password: 'password',
+            role: 1)

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -15,24 +15,29 @@ Speaker.create(name: "Speaker Name")
 Story.create(title: "Fa di Saamaka sembe bi haba a beligi",
              desc: "Het is al geruime tijd een bekend gegeven dat een lezer, tijdens het bekijken van de layout van een pagina, afgeleid wordt door de tekstuele inhoud. Het belangrijke punt van het gebruik van Lorem Ipsum is dat het uit een min of meer normale verdeling van letters bestaat, in tegenstelling tot 'Hier uw tekst, hier uw tekst' wat het tot min of meer leesbaar nederlands maakt.",
              speaker: Speaker.first,
-             point: Point.first)
+             point: Point.first,
+             permission_level: 0)
 
 Story.create(title: "Di twaalfu lampeesi fu Toido",
              desc: "Veel desktop publishing pakketten en web pagina editors gebruiken tegenwoordig Lorem Ipsum als hun standaard model tekst, en een zoekopdracht naar 'lorem ipsum' ontsluit veel websites die nog in aanbouw zijn. Verscheidene versies hebben zich ontwikkeld in de loop van de jaren, soms per ongeluk soms expres (ingevoegde humor en dergelijke).",
              speaker: Speaker.first,
-             point: Point.first)
+             point: Point.first,
+             permission_level: 0)
 
 Story.create(title: "Fa di gaan sembe veloisi go aki",
              desc: "r zijn vele variaties van passages van Lorem Ipsum beschikbaar maar het merendeel heeft te lijden gehad van wijzigingen in een of andere vorm, door ingevoegde humor of willekeurig gekozen woorden die nog niet half geloofwaardig ogen.",
              speaker: Speaker.first,
-             point: Point.second)
+             point: Point.second,
+             permission_level: 1)
 
 Story.create(title: "Mama Tjowa",
              desc: "Als u een passage uit Lorum Ipsum gaat gebruiken dient u zich ervan te verzekeren dat er niets beschamends midden in de tekst verborgen zit. Alle Lorum Ipsum generators op Internet hebben de eigenschap voorgedefinieerde stukken te herhalen waar nodig zodat dit de eerste echte generator is op internet.",
              speaker: Speaker.first,
-             point: Point.third)
+             point: Point.third,
+             permission_level: 1)
 
 Story.create(title: "Fa di Kwinti nengeb bi feti ku Matawai sembe",
              desc: "In tegenstelling tot wat algemeen aangenomen wordt is Lorem Ipsum niet zomaar willekeurige tekst. het heeft zijn wortels in een stuk klassieke latijnse literatuur uit 45 v.Chr. en is dus meer dan 2000 jaar oud.",
              speaker: Speaker.first,
-             point: Point.fourth)
+             point: Point.fourth,
+             permission_level: 1)


### PR DESCRIPTION
This PR adds two new fields as enums:
permission_level on Story (:anonymous, :user_only, :editor_only)
role on User (:user, :editor) 

I also included a policy for Stories and updated the helper method for viewing only the Stories that the current user has permission for.

This PR also updates and cleans up the Administrate dashboards so they work without any errors! This should make the dashboards more readable and easier to navigate and create new stories. You can create users, delete users, and edit their passwords. (Unsure why the password field doesn't actually show up in the dashboard - it could be a security thing so I didn't look into trying to fix that yet.) You can also set the permission level on a Story which will determine which can be viewed in the map page. 

There is also some new authentication logic for viewing the admin page. You will need to be logged in, and have the Editor role to view the admin dashboards. I included an Editor user in the seeds file for development purposes. 

I also temporarily changed the Welcome page to display the current user's email address if logged in, a link to edit their own profile or log out, and if not logged in, a link to sign up or log in. This is a temporary change to help with development, I plan on creating a new issue to clean this up in the UI. 

Things I would like to add next:
Update the card component to display the actual user's information, with log out and edit profile links
Update the welcome card to display the admin information (including a link to the admin dashboard) if the user is logged in as an admin/editor. 

