### PR TITLE
asset pipeline fixes to make it happy in Heroku

### DIFF
--- a/rails/app/assets/stylesheets/components/_components.scss
+++ b/rails/app/assets/stylesheets/components/_components.scss
@@ -8,4 +8,4 @@
 @import 'speaker';
 @import 'welcome';
 @import 'balloon';
-@import 'IntroPopup';
+@import 'introPopup';

--- a/rails/app/assets/stylesheets/core/_typography.scss
+++ b/rails/app/assets/stylesheets/core/_typography.scss
@@ -1,6 +1,6 @@
 @font-face {
   font-family: 'OpenSansCondensed';
-  src: url('OpenSansCondensed-Bold.ttf') format('truetype');
+  src: url($open-sans-condensed-path) format('truetype');
   font-weight: normal;
   font-style: normal;
 }

--- a/rails/app/assets/stylesheets/core/_variables.scss.erb
+++ b/rails/app/assets/stylesheets/core/_variables.scss.erb
@@ -1,0 +1,1 @@
+$open-sans-condensed-path: "<%= asset_path('OpenSansCondensed-Bold.ttf') %>";

--- a/rails/app/views/home/_card.html.erb
+++ b/rails/app/views/home/_card.html.erb
@@ -1,6 +1,6 @@
 <div class="card">
   <div class="logo">
-    <%= image_tag 'logocombo', alt: 'Terrastories' %>
+    <%= image_tag 'logocombo.svg', alt: 'Terrastories' %>
   </div>
   <div class="intro">
     <h1>Introduction</h1>

--- a/rails/app/views/welcome/index.html.erb
+++ b/rails/app/views/welcome/index.html.erb
@@ -1,6 +1,6 @@
 <div id="welcome-page">
   <div class="welcome-card">
-    <%= image_tag 'logocombo', alt: 'Terrastories' %>
+    <%= image_tag 'logocombo.svg', alt: 'Terrastories' %>
     <h1>Welcome</h1>
 
     <%= button_tag(type: 'button', class: "l--75") do %>

--- a/rails/config/environments/production.rb
+++ b/rails/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
* set JS compressor to use harmony mode for ES6

Resolves the following error when compiling assets:

    Uglifier::Error: Unexpected token: punc ()). To use ES6 syntax,
    harmony mode must be enabled with Uglifier.new(:harmony => true).

* fix import to match case with filename, `IntroPopup != introPopup`
* updated `image_tag` calls to use the complete image filename to avoid asset pipeline lookup misses in production