### PR TITLE
Add convenience scripts to ease development and deployment

### DIFF
--- a/conf/terrastories.conf
+++ b/conf/terrastories.conf
@@ -1,0 +1,7 @@
+description "Start the Terrastories server"
+author "Jason Hinebaugh"
+
+start on started docker
+stop on stopping docker
+
+exec /bin/terrastories-start

--- a/script/console
+++ b/script/console
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose exec rails bash

--- a/script/logs
+++ b/script/logs
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker-compose logs -f rails

--- a/script/prod/bootstrap
+++ b/script/prod/bootstrap
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Install docker if not already installed
+if [ "$(which docker)" == "" ]; then
+  sudo apt-get install -y apt-transport-https ca-certificates software-properties-common
+
+  # First, add the GPG key for the official Docker repository to the system:
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+  # Add the Docker repository to APT sources:
+  sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
+  # Next, update the package database with the Docker packages from the newly added repo:
+  sudo apt-get update
+
+  #Finally, install Docker:
+  sudo apt-get install -y docker-ce
+fi
+
+if [ "$(which docker-compose)" == "" ]; then
+  sudo curl -L "https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m)" -o /bin/docker-compose
+  chmod a+x /bin/docker-compose
+fi

--- a/script/prod/install
+++ b/script/prod/install
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+do_uninstall() {
+  service stop terrastories
+  rm /etc/init/terrastories.conf
+  rm /bin/terrastories-start
+  rm /bin/terrastories-update
+  rm -rf /opt/terrastories
+}
+
+do_install() {
+  # Clone the terrastories repository to a known location in /opt/terrastories
+  git clone https://github.com/rubyforgood/terrastories.git /opt/terrastories
+  cd /opt/terrastories && bin/bootstrap && bin/setup
+
+  # Create a symbolic link to the executable scripts in /bin
+  cd /bin && ln -s /opt/terrastories/bin/start terrastories-start
+  cd /bin && ln -s /opt/terrastories/bin/update terrastories-update
+
+  # Create a symbolic link to the upstart service configuration
+  cd /etc/init && ln -s /opt/terrastories/conf/terrastories.conf
+
+  # Stat the terrastories service
+  initctl reload-configuration
+  service terrastories start
+}
+
+prompt_for_install() {
+  while true; do
+      read -p "This is not a typical development command. It will install \
+terrastories as a service intended for a deployed production environment. Are \
+you sure you want to proceed? y/N " yn
+      case $yn in
+          [Yy]* ) do_uninstall && do_install; break;;
+          * ) exit;;
+      esac
+  done
+}
+
+main() {
+  force_yes=0
+
+  while getopts ":y" opt; do
+    case $opt in
+      y)
+        force_yes=1
+        ;;
+      \?)
+        echo "Invalid option: -$OPTARG" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [ $force_yes == 1 ]; then
+    do_uninstall && do_install;
+  else
+    prompt_for_install
+  fi
+}
+
+main

--- a/script/prod/setup
+++ b/script/prod/setup
@@ -1,0 +1,5 @@
+#!/bin/bash
+service docker start
+cd $(dirname $(readlink -f $0))
+docker-compose build
+docker-compose run tileserver

--- a/script/prod/uninstall
+++ b/script/prod/uninstall
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+do_uninstall() {
+  service stop terrastories
+  rm /etc/init/terrastories.conf
+  rm /bin/terrastories-start
+  rm /bin/terrastories-update
+  rm -rf /opt/terrastories
+}
+
+prompt_for_uninstall() {
+  while true; do
+    read -p "This is not a typical development command. It will uninstall \
+terrastories and remove all its related files from a deployed environment.\
+Are you sure you want to proceed? y/N " yn
+    case $yn in
+      [Yy]* ) do_uninstall; break;;
+      * ) exit;;
+    esac
+  done
+}
+
+main() {
+  force_yes=0
+
+  while getopts ":y" opt; do
+    case $opt in
+      y)
+        force_yes=1
+        ;;
+      \?)
+        echo "Invalid option: -$OPTARG" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [ $force_yes == 1 ]; then
+    do_uninstall;
+  else
+    prompt_for_uninstall
+  fi
+}
+
+main

--- a/script/server
+++ b/script/server
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose up nginx

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker-compose build
+docker-compose run tileserver

--- a/script/setup
+++ b/script/setup
@@ -1,3 +1,3 @@
 #!/bin/bash
 docker-compose build
-docker-compose run tileserver
+docker-compose run --rm --name build_the_tiles tilebuilder

--- a/script/start
+++ b/script/start
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose up -d nginx

--- a/script/stop
+++ b/script/stop
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose down

--- a/script/update
+++ b/script/update
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker-compose down > /dev/null 2>&1
+docker-compose build


### PR DESCRIPTION
This is an almost-faithful implementation of [these github conventions](https://github.com/github/scripts-to-rule-them-all). It adds several utility scripts that normalize some of the more arcane docker commands into more readily understood ones.

`bin/bootstrap`
Installs dependencies. For this project, that's just docker. (Also, this script currently only works in a Debian-flavored Linux environment. Sorry!)

`bin/setup`
Performs first-time setup. For this project, that means building all images and running tile-builder for the first time.

`bin/update`
Performs appropriate tasks after a fresh pull from github. For this project, that means rebuilding docker images so that gems and node modules are cached.

`bin/server`
Run the server and log output from nginx. Once started, the app should be available at [localhost:3000](http://localhost:3000).

`bin/logs`Show the live logging output from the running rails container. This will fail if the container isn't running.

`bin/console`: Start an interactive shell session on the running rails container. This will fail if the container isn't running.

Additional scripts to be aware of:
`bin/start` and `bin/stop`: Start and stop the app much like `bin/server`, but do so in detached mode. This is my personally preferred way to run the app. Most people would expect some ongoing output after starting their sever, so I'm keeping these distinct from `bin/server`.

`bin/install` and `bin/uninstall`: Intended for use in deployed environments, not development. These expect to have root permissions on an Ubuntu system. The install script also copies the upstart/initctl configuration to run terrastories as a service whenever the docker service is started. These are untested and potentially dangerous scripts. Please don't run them on your development machine.

Despite my stern warning about the install script, I do need some help testing it. It is intended to provide a one-line self-installation option to make it easier to install the application on a NUC or similar hardware. ~~The command for testing that installation is:~~
~~curl https://raw.githubusercontent.com/rubyforgood/terrastories/convenience-scripts/bin/install | sh~~
[_nvm don't do this; see comment below_]

I haven't been able to test this despite having the POSM image up and running locally with VirtualBox simply because VirtualBox isn't letting the VM use my network connection. Any help is appreciated!