### PR TITLE
fix Card/Story Scrolling

### DIFF
--- a/rails/app/assets/stylesheets/components/card.scss
+++ b/rails/app/assets/stylesheets/components/card.scss
@@ -146,11 +146,11 @@ $el-shadow: 0 1px 4px #bbb;
 
 .stories {
   flex: 0 5 auto;
-  overflow: hidden;
+  overflow: auto;
 
   ul {
     margin: 0 0 0.5rem;
-    max-height: 460px;
+    max-height: inherit;
     overflow-y: scroll;
     overflow-x: hidden;
     padding: 0 2px;


### PR DESCRIPTION
## What

Fixes #104 

This fixes the scrolling of the Card component that contains a list of
stories.

Setting max-height to a specific number will cause a breakpoint on small
screens and cause scrolling to be hidden.

Also, setting `overflow: hidden` on parents elements can cause an effect
of no-scroll, even when `overflow: scroll` is specified on a childe
element.

## Notes

This was only reproducible for me on super tiny screens.

## Demo

Top browser is Safari. Bottom is Chrome.

| Before | After |
| --- | --- |
| ![ts-scroll-before](https://user-images.githubusercontent.com/2660801/46090195-32601d80-c17e-11e8-9a4c-e35608cdf304.gif) | ![ts-scroll-after](https://user-images.githubusercontent.com/2660801/46090194-32601d80-c17e-11e8-9a4c-aa17954f770e.gif) |