### PR TITLE
Mapbox switcher

### DIFF
--- a/rails/app/javascript/components/App.jsx
+++ b/rails/app/javascript/components/App.jsx
@@ -112,8 +112,13 @@ class App extends Component {
   render() {
     return (
       <div>
-        <Map points={this.state.points} pointCoords={this.state.coords}/>
-        <Card 
+        <Map
+          points={this.state.points}
+          pointCoords={this.state.coords}
+          mapboxAccessToken={this.props.mapbox_access_token}
+          mapboxStyle={this.props.mapbox_style}
+        />
+        <Card
           stories={this.state.stories}
           categories={FILTER_CATEGORIES}
           filterMap={this.filterMap()}

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -19,7 +19,7 @@ export default class Map extends Component {
 
     this.map = new mapboxgl.Map({
       container: this.mapContainer,
-      style: '/tiles/styles/basic/style.json',
+      style: this.props.mapboxStyle,
       // style: 'mapbox://styles/kalimar/cjl1ia62y7ye52rn060umypfr',
       center: [-55.63, 4.78],
       zoom: 7.6,

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 
-// mapboxgl.accessToken = 'pk.eyJ1Ijoia2FsaW1hciIsImEiOiJjajdhdmNtMjkwbGZlMzJyc2RvNmhjZXd3In0.tBIY2rRDHYt1VYeGTOH98g';
 
 export default class Map extends Component {
   constructor(props) {
     super(props);
+    mapboxgl.accessToken = this.props.mapboxAccessToken;
   }
 
   // I wonder if component will receive props is how we want to execute the flyTo
@@ -20,7 +20,6 @@ export default class Map extends Component {
     this.map = new mapboxgl.Map({
       container: this.mapContainer,
       style: this.props.mapboxStyle,
-      // style: 'mapbox://styles/kalimar/cjl1ia62y7ye52rn060umypfr',
       center: [-55.63, 4.78],
       zoom: 7.6,
       maxBounds: bounds

--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -12,3 +12,5 @@ json.stories stories do |story|
 end
 json.logo_path image_path("logocombo.svg")
 json.user current_user
+json.mapbox_access_token ENV["MAPBOX_ACCESS_TOKEN"]
+json.mapbox_style ENV["MAPBOX_STYLE"] || "/tiles/styles/basic/style.json"


### PR DESCRIPTION
## What

This codifies the logic for switching between the local tile style and the Mapbox style.

## Notes

This sets up and relies on ENV to be set. Since this is deployed to Heroku, we'll need to configure Heroku for two new environment variables:

- MAPBOX_ACCESS_TOKEN
- MAPBOX_STYLE

See [Slack Convo about Mapbox Style](https://rubyforgood.slack.com/archives/CAH9XQX2A/p1538403515000100?thread_ts=1538403332.000100&cid=CAH9XQX2A) and [Slack Convo about Access Token](https://rubyforgood.slack.com/archives/CAH9XQX2A/p1538403779000100?thread_ts=1538403332.000100&cid=CAH9XQX2A) for the correct string values.