### PR TITLE
Add Administrate Localizations

### DIFF
--- a/rails/app/controllers/admin/application_controller.rb
+++ b/rails/app/controllers/admin/application_controller.rb
@@ -9,6 +9,18 @@ module Admin
     before_action :authenticate_user!
     before_action :authenticate_admin
 
+    before_action :set_locale
+
+    def default_url_options
+      { locale: I18n.locale }
+    end
+
+    private
+
+    def set_locale
+      I18n.locale = params[:locale] || I18n.default_locale
+    end
+
     def authenticate_admin
       redirect_to '/', alert: 'Not authorized.' unless current_user && current_user.editor?
     end

--- a/rails/config/locales/administrate.mat.yml
+++ b/rails/config/locales/administrate.mat.yml
@@ -1,0 +1,28 @@
+---
+mat:
+  administrate:
+    actions:
+      confirm: Weet u het zeker?
+      destroy: Verwijder
+      edit: Bewerk
+      edit_resource: Bewerk %{name}
+      show_resource: Toon %{name}
+      new_resource: Nieuw %{name}
+      back: Terug
+    controller:
+      create:
+        success: "%{resource} was succesvol aangemaakt."
+      destroy:
+        success: "%{resource} was succesvol verwijderd."
+      update:
+        success: "%{resource} was succesvol geupdated."
+    fields:
+      has_many:
+        more: Resultaat %{count} van %{total_count}
+        none: Geen
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    search:
+      clear: CDuidelijke zoek
+      label: Zoeken %{resource}


### PR DESCRIPTION
## What

This copies the administrate gem's nl / Dutch translations and copies
them to our Matawai translations.

Good enough for now, and it'll stop breaking the Administrate admin
panel when in mat locale.

## Notes

Because Administrate uses the name of the models for the navigation links on the side, those will remain in English for now.

## Demo

![image](https://user-images.githubusercontent.com/2660801/46413937-0b5e9a00-c6f0-11e8-924c-5dd4535c0fbe.png)
