### PR TITLE
Administrate updates - Remove media from Story index and add fallback for Enum fields

### DIFF
--- a/rails/app/dashboards/story_dashboard.rb
+++ b/rails/app/dashboards/story_dashboard.rb
@@ -30,7 +30,6 @@ class StoryDashboard < Administrate::BaseDashboard
     :desc,
     :speaker,
     :point,
-    :media,
     :permission_level
   ].freeze
 

--- a/rails/app/views/fields/enum_field/_index.html.erb
+++ b/rails/app/views/fields/enum_field/_index.html.erb
@@ -1,1 +1,5 @@
-<%= field.to_s.titleize %>
+<% if field %>
+  <%= field.to_s.titleize %>
+<% else %>
+  Not Set
+<% end %>

--- a/rails/app/views/fields/enum_field/_show.html.erb
+++ b/rails/app/views/fields/enum_field/_show.html.erb
@@ -1,1 +1,5 @@
-<%= field.to_s.titleize %>
+<% if field %>
+  <%= field.to_s.titleize %>
+<% else %>
+  Not Set
+<% end %>


### PR DESCRIPTION
This removes displaying the media attachment on the Story index dashboard. They are visible when you click into a specific story. This will be helpful so we don't have a ton of videos loading on the admin page all at once.

I also added a fallback for the way the Enum fields are being displayed in case a Story or User doesn't have it set for some reason.