### PR TITLE
Add basic styling to devise pages

### DIFF
--- a/rails/app/assets/stylesheets/components/_components.scss
+++ b/rails/app/assets/stylesheets/components/_components.scss
@@ -7,5 +7,6 @@
 @import 'player';
 @import 'speaker';
 @import 'welcome';
+@import 'devise';
 @import 'balloon';
 @import 'introPopup';

--- a/rails/app/assets/stylesheets/components/devise.scss
+++ b/rails/app/assets/stylesheets/components/devise.scss
@@ -1,0 +1,140 @@
+.devise {
+  background: image-url('welcome-bg.jpg') no-repeat center center fixed;
+  background-size: cover;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+
+  .logo {
+  	  img {
+		width: 50%;
+	  }
+	}
+
+  &-card {
+    background: rgba(255,255,255,0.70);
+    width: 55%;
+    padding: 2em;
+    border-radius: 5%;
+    color: #136A7E;
+    max-width: 25rem;
+    height: 20rem;
+    display: flex;
+    flex-direction: column;
+	margin-bottom: 40px;
+	flex-shrink: 0;
+
+    @media screen and (max-width: 600px) {
+      width: 80vw;
+    }
+
+    img {
+      margin-bottom: 0.5rem;
+      width: 100%;
+    }
+
+    &-user {
+      color: #5AA68D;
+      margin-top: 1rem;
+	  margin-bottom: 1rem;
+      width: 100%;
+
+      a {
+        @media screen and (max-width: 600px) {
+          letter-spacing: 0;
+        }
+        text-decoration: none;
+        color: #5AA68D;
+        text-transform: uppercase;
+        letter-spacing: .09rem;
+        font-family: sans-serif;
+        font-weight: bold;
+        font-size: 0.85rem;
+        margin-right: 1rem;
+        margin-left: 1rem;
+
+        &:hover {
+          color: #136A7E;
+        }
+      }
+    }
+
+    h1 {
+      border-top: 3px solid #D77A34;
+      padding-top: 0.3em;
+	  padding-bottom: 0.2em;
+      text-align: center;
+      margin: 0;
+    }
+
+    a {
+      color: #5AA68D;
+      text-decoration: none;
+      align-self: center;
+    }
+
+    button {
+      background-color: #5AA68D;
+      text-transform: uppercase;
+      letter-spacing: .09rem;
+      display: block;
+      border-radius: 5px;
+      border-color: transparent;
+      font-weight: 400;
+      font-size: 0.85rem;
+      cursor: pointer;
+      padding: 1rem;
+      width: 15rem;
+      margin-top: 0.5rem;
+      color: white;
+
+      &:hover {
+        background-color: #136A7E;
+      }
+
+      &:focus {
+        outline-color: #fff;
+      }
+    }
+  }
+
+  @include for-phone-only {
+	.logo {
+	  height: 25%;
+	}
+  }
+
+  @media screen and (max-width: 370px) {
+    h1 {
+	  font-size: 1.5rem;
+	}
+
+	button {
+	  width: 10rem;
+	}
+
+	.navbar-link {
+	  margin-left: 5px;
+	  margin-right: 5px;
+	  font-size: 0.6em;
+	}
+
+	.language-picker {
+	  font-size: 0.7em;
+	}
+  }
+
+  @media screen and (max-height: 450px) {
+	.logo {
+	  display: none;
+	}
+
+	.welcome-card {
+	  margin-bottom: 0;
+	}
+  }
+
+}

--- a/rails/app/assets/stylesheets/components/devise.scss
+++ b/rails/app/assets/stylesheets/components/devise.scss
@@ -9,24 +9,22 @@
   text-align: center;
 
   .logo {
-  	  img {
-		width: 50%;
-	  }
-	}
+    img {
+      width: 50%;
+    }
+  }
 
   &-card {
-    background: rgba(255,255,255,0.70);
+    background: $card-background;
     width: 55%;
     padding: 2em;
     border-radius: 5%;
-    color: #136A7E;
+    color: $blue;
     max-width: 25rem;
-    height: 20rem;
     display: flex;
     flex-direction: column;
-	margin-bottom: 40px;
-	flex-shrink: 0;
-
+    margin-bottom: 40px;
+    flex-shrink: 0;
     @media screen and (max-width: 600px) {
       width: 80vw;
     }
@@ -36,51 +34,35 @@
       width: 100%;
     }
 
-    &-user {
-      color: #5AA68D;
-      margin-top: 1rem;
-	  margin-bottom: 1rem;
-      width: 100%;
-
-      a {
-        @media screen and (max-width: 600px) {
-          letter-spacing: 0;
-        }
-        text-decoration: none;
-        color: #5AA68D;
-        text-transform: uppercase;
-        letter-spacing: .09rem;
-        font-family: sans-serif;
-        font-weight: bold;
-        font-size: 0.85rem;
-        margin-right: 1rem;
-        margin-left: 1rem;
-
-        &:hover {
-          color: #136A7E;
-        }
-      }
-    }
-
     h1 {
-      border-top: 3px solid #D77A34;
+      border-top: 3px solid $orange;
       padding-top: 0.3em;
-	  padding-bottom: 0.2em;
+      padding-bottom: 0.2em;
       text-align: center;
       margin: 0;
     }
 
     a {
-      color: #5AA68D;
+      color: $teal;
       text-decoration: none;
       align-self: center;
     }
 
-    button {
-      background-color: #5AA68D;
+    input[type=text],
+    input[type=email],
+    input[type=password] {
+      padding: 0.5rem;
+      width: 100%;
+    }
+
+    label {
+      margin-top: 1rem;
+    }
+
+    input[type=submit] {
+      background-color: $teal;
       text-transform: uppercase;
-      letter-spacing: .09rem;
-      display: block;
+      letter-spacing: 0.09rem;
       border-radius: 5px;
       border-color: transparent;
       font-weight: 400;
@@ -89,52 +71,48 @@
       padding: 1rem;
       width: 15rem;
       margin-top: 0.5rem;
-      color: white;
+      color: $white;
 
       &:hover {
-        background-color: #136A7E;
+        background-color: $blue;
       }
 
       &:focus {
-        outline-color: #fff;
+        outline-color: $white;
       }
     }
   }
-
   @include for-phone-only {
-	.logo {
-	  height: 25%;
-	}
+    .logo {
+      height: 25%;
+    }
   }
-
   @media screen and (max-width: 370px) {
     h1 {
-	  font-size: 1.5rem;
-	}
+      font-size: 1.5rem;
+    }
 
-	button {
-	  width: 10rem;
-	}
+    input[type=submit] {
+      width: 10rem;
+    }
 
-	.navbar-link {
-	  margin-left: 5px;
-	  margin-right: 5px;
-	  font-size: 0.6em;
-	}
-
-	.language-picker {
-	  font-size: 0.7em;
-	}
+    .navbar-link {
+      margin-left: 5px;
+      margin-right: 5px;
+      font-size: 0.6em;
+    }
   }
-
   @media screen and (max-height: 450px) {
-	.logo {
-	  display: none;
-	}
+    .logo {
+      display: none;
+    }
 
-	.welcome-card {
-	  margin-bottom: 0;
-	}
+    .devise-card {
+      margin-bottom: 0;
+    }
   }
 
+  &-links {
+    margin-top: 1rem;
+  }
 }

--- a/rails/app/assets/stylesheets/components/welcome.scss
+++ b/rails/app/assets/stylesheets/components/welcome.scss
@@ -7,26 +7,25 @@
   justify-content: center;
   align-items: center;
   text-align: center;
-  
+
   .logo {
-  	  img {
-		width: 50%;
-	  }
-	}
-  
+    img {
+      width: 50%;
+    }
+  }
+
   &-card {
-    background: rgba(255,255,255,0.70);
+    background: $card-background;
     width: 55%;
     padding: 2em;
     border-radius: 5%;
-    color: #136A7E;
+    color: $blue;
     max-width: 25rem;
     height: 20rem;
     display: flex;
     flex-direction: column;
-	margin-bottom: 40px;
-	flex-shrink: 0;
-
+    margin-bottom: 40px;
+    flex-shrink: 0;
     @media screen and (max-width: 600px) {
       width: 80vw;
     }
@@ -37,9 +36,9 @@
     }
 
     &-user {
-      color: #5AA68D;
+      color: $teal;
       margin-top: 1rem;
-	  margin-bottom: 1rem;
+      margin-bottom: 1rem;
       width: 100%;
 
       a {
@@ -47,9 +46,9 @@
           letter-spacing: 0;
         }
         text-decoration: none;
-        color: #5AA68D;
+        color: $teal;
         text-transform: uppercase;
-        letter-spacing: .09rem;
+        letter-spacing: 0.09rem;
         font-family: sans-serif;
         font-weight: bold;
         font-size: 0.85rem;
@@ -57,29 +56,29 @@
         margin-left: 1rem;
 
         &:hover {
-          color: #136A7E;
+          color: $blue;
         }
       }
     }
 
     h1 {
-      border-top: 3px solid #D77A34;
-      padding-top: 0.3em; 
-	  padding-bottom: 0.2em;
+      border-top: 3px solid $orange;
+      padding-top: 0.3em;
+      padding-bottom: 0.2em;
       text-align: center;
       margin: 0;
     }
 
     a {
-      color: #5AA68D;
+      color: $teal;
       text-decoration: none;
       align-self: center;
     }
-  
+
     button {
-      background-color: #5AA68D;
+      background-color: $teal;
       text-transform: uppercase;
-      letter-spacing: .09rem;
+      letter-spacing: 0.09rem;
       display: block;
       border-radius: 5px;
       border-color: transparent;
@@ -89,53 +88,49 @@
       padding: 1rem;
       width: 15rem;
       margin-top: 0.5rem;
-      color: white;
-  
+      color: $white;
+
       &:hover {
-        background-color: #136A7E;
+        background-color: $blue;
       }
-  
+
       &:focus {
-        outline-color: #fff;
+        outline-color: $white;
       }
     }
   }
 
   @include for-phone-only {
-	.logo { 
-	  height: 25%; 
-	}
+    .logo {
+      height: 25%;
+    }
   }
-
   @media screen and (max-width: 370px) {
-    h1 { 
-	  font-size: 1.5rem; 
-	}
-    
-	button { 
-	  width: 10rem; 
-	}
-	
-	.navbar-link {
-	  margin-left: 5px;
-	  margin-right: 5px;
-	  font-size: 0.6em;
-	}
-	
-	.language-picker { 
-	  font-size: 0.7em;
-	}
+    h1 {
+      font-size: 1.5rem;
+    }
+
+    button {
+      width: 10rem;
+    }
+
+    .navbar-link {
+      margin-left: 5px;
+      margin-right: 5px;
+      font-size: 0.6em;
+    }
+
+    .language-picker {
+      font-size: 0.7em;
+    }
   }
-  
   @media screen and (max-height: 450px) {
-	.logo { 
-	  display: none; 
-	}
+    .logo {
+      display: none;
+    }
 
-	.welcome-card {
-	  margin-bottom: 0;
-	}
-  }  
-  
+    .welcome-card {
+      margin-bottom: 0;
+    }
+  }
 }
-

--- a/rails/app/assets/stylesheets/core/_colors.scss
+++ b/rails/app/assets/stylesheets/core/_colors.scss
@@ -1,0 +1,5 @@
+$teal: #5aa68d;
+$blue: #136a7e;
+$white: #ffffff;
+$orange: #d77a34;
+$card-background: rgba(255,255,255,0.70);

--- a/rails/app/views/devise/confirmations/new.html.erb
+++ b/rails/app/views/devise/confirmations/new.html.erb
@@ -6,7 +6,7 @@
       <%= devise_error_messages! %>
 
       <div class="field">
-        <%= f.label :email %><br />
+        <%= f.label :email %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
       </div>
 

--- a/rails/app/views/devise/confirmations/new.html.erb
+++ b/rails/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,20 @@
-<h2>Resend confirmation instructions</h2>
+<div class="devise">
+  <div class="devise-card">
+    <h2>Resend confirmation instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+      <%= devise_error_messages! %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "Resend confirmation instructions" %>
+      </div>
+    <% end %>
+
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/rails/app/views/devise/passwords/edit.html.erb
+++ b/rails/app/views/devise/passwords/edit.html.erb
@@ -7,15 +7,15 @@
       <%= f.hidden_field :reset_password_token %>
 
       <div class="field">
-        <%= f.label :password, "New password" %><br />
+        <%= f.label :password, "New password" %>
         <% if @minimum_password_length %>
-          <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+          <em>(<%= @minimum_password_length %> characters minimum)</em>
         <% end %>
         <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
       </div>
 
       <div class="field">
-        <%= f.label :password_confirmation, "Confirm new password" %><br />
+        <%= f.label :password_confirmation, "Confirm new password" %>
         <%= f.password_field :password_confirmation, autocomplete: "off" %>
       </div>
 

--- a/rails/app/views/devise/passwords/edit.html.erb
+++ b/rails/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,29 @@
-<h2>Change your password</h2>
+<div class="devise">
+  <div class="devise-card">
+    <h2>Change your password</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= devise_error_messages! %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <div class="field">
+        <%= f.label :password, "New password" %><br />
+        <% if @minimum_password_length %>
+          <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+        <% end %>
+        <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password_confirmation, "Confirm new password" %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "off" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "Change my password" %>
+      </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/rails/app/views/devise/passwords/new.html.erb
+++ b/rails/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,20 @@
-<h2>Forgot your password?</h2>
+<div class="devise">
+  <div class="devise-card">
+    <h2>Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= devise_error_messages! %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "Send me reset password instructions" %>
+      </div>
+    <% end %>
+
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/rails/app/views/devise/passwords/new.html.erb
+++ b/rails/app/views/devise/passwords/new.html.erb
@@ -6,7 +6,7 @@
       <%= devise_error_messages! %>
 
       <div class="field">
-        <%= f.label :email %><br />
+        <%= f.label :email %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
       </div>
 

--- a/rails/app/views/devise/registrations/edit.html.erb
+++ b/rails/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,47 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="devise">
+  <div class="devise-card">
+    <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= devise_error_messages! %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+      <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <div class="field">
+        <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+        <%= f.password_field :password, autocomplete: "off" %>
+        <% if @minimum_password_length %>
+          <br />
+          <em><%= @minimum_password_length %> characters minimum</em>
+        <% end %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password_confirmation %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "off" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+        <%= f.password_field :current_password, autocomplete: "off" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "Update" %>
+      </div>
     <% end %>
+
+    <h3>Cancel my account</h3>
+
+    <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+    <%= link_to "Back", :back %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>

--- a/rails/app/views/devise/registrations/edit.html.erb
+++ b/rails/app/views/devise/registrations/edit.html.erb
@@ -6,7 +6,7 @@
       <%= devise_error_messages! %>
 
       <div class="field">
-        <%= f.label :email %><br />
+        <%= f.label :email %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
       </div>
 
@@ -15,21 +15,21 @@
       <% end %>
 
       <div class="field">
-        <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+        <%= f.label :password %> <i>(leave blank if you don't want to change it)</i>
         <%= f.password_field :password, autocomplete: "off" %>
         <% if @minimum_password_length %>
-          <br />
+
           <em><%= @minimum_password_length %> characters minimum</em>
         <% end %>
       </div>
 
       <div class="field">
-        <%= f.label :password_confirmation %><br />
+        <%= f.label :password_confirmation %>
         <%= f.password_field :password_confirmation, autocomplete: "off" %>
       </div>
 
       <div class="field">
-        <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+        <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i>
         <%= f.password_field :current_password, autocomplete: "off" %>
       </div>
 

--- a/rails/app/views/devise/registrations/new.html.erb
+++ b/rails/app/views/devise/registrations/new.html.erb
@@ -6,7 +6,7 @@
       <%= devise_error_messages! %>
 
       <div class="field">
-        <%= f.label :email %><br />
+        <%= f.label :email %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
       </div>
 
@@ -14,12 +14,12 @@
         <%= f.label :password %>
         <% if @minimum_password_length %>
         <em>(<%= @minimum_password_length %> characters minimum)</em>
-        <% end %><br />
+        <% end %>
         <%= f.password_field :password, autocomplete: "off" %>
       </div>
 
       <div class="field">
-        <%= f.label :password_confirmation %><br />
+        <%= f.label :password_confirmation %>
         <%= f.password_field :password_confirmation, autocomplete: "off" %>
       </div>
 

--- a/rails/app/views/devise/registrations/new.html.erb
+++ b/rails/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,33 @@
-<h2>Sign up</h2>
+<div class="devise">
+  <div class="devise-card">
+    <h2>Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= devise_error_messages! %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= devise_error_messages! %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password %>
+        <% if @minimum_password_length %>
+        <em>(<%= @minimum_password_length %> characters minimum)</em>
+        <% end %><br />
+        <%= f.password_field :password, autocomplete: "off" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password_confirmation %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "off" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "Sign up" %>
+      </div>
+    <% end %>
+
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/rails/app/views/devise/sessions/new.html.erb
+++ b/rails/app/views/devise/sessions/new.html.erb
@@ -4,12 +4,12 @@
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="field">
-        <%= f.label :email %><br />
+        <%= f.label :email %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
       </div>
 
       <div class="field">
-        <%= f.label :password, t("password") %><br />
+        <%= f.label :password, t("password") %>
         <%= f.password_field :password, autocomplete: "off" %>
       </div>
 

--- a/rails/app/views/devise/sessions/new.html.erb
+++ b/rails/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,30 @@
-<h2><%= t("login") %></h2>
+<div class="devise">
+  <div class="devise-card">
+    <h2><%= t("login") %></h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password, t("password") %><br />
+        <%= f.password_field :password, autocomplete: "off" %>
+      </div>
+
+      <% if devise_mapping.rememberable? -%>
+        <div class="field">
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me, t("remember_me") %>
+        </div>
+      <% end -%>
+
+      <div class="actions">
+        <%= f.submit "Log in", value: t("login") %>
+      </div>
+    <% end %>
+
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password, t("password") %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <% if devise_mapping.rememberable? -%>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me, t("remember_me") %>
-    </div>
-  <% end -%>
-
-  <div class="actions">
-    <%= f.submit "Log in", value: t("login") %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/rails/app/views/devise/shared/_links.html.erb
+++ b/rails/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,27 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to t("login"), new_session_path(resource_name) %><br />
-<% end -%>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to t("sign_up"), new_registration_path(resource_name) %><br />
-<% end -%>
-
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to t("forgot_password"), new_password_path(resource_name) %><br />
-<% end -%>
-
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end -%>
-
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end -%>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+<ul class="devise-links">
+  <%- if controller_name != 'sessions' %>
+    <li><%= link_to t("login"), new_session_path(resource_name) %></li>
   <% end -%>
-<% end -%>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <li><%= link_to t("sign_up"), new_registration_path(resource_name) %></li>
+  <% end -%>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <li><%= link_to t("forgot_password"), new_password_path(resource_name) %></li>
+  <% end -%>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <li><%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %></li>
+  <% end -%>
+
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <li><%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %></li>
+  <% end -%>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <li><%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %></li>
+    <% end -%>
+  <% end -%>
+</ul>

--- a/rails/app/views/devise/unlocks/new.html.erb
+++ b/rails/app/views/devise/unlocks/new.html.erb
@@ -1,16 +1,20 @@
-<h2>Resend unlock instructions</h2>
+<div class="devise">
+  <div class="devise-card">
+    <h2>Resend unlock instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+    <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+      <%= devise_error_messages! %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "Resend unlock instructions" %>
+      </div>
+    <% end %>
+
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/rails/app/views/devise/unlocks/new.html.erb
+++ b/rails/app/views/devise/unlocks/new.html.erb
@@ -6,7 +6,7 @@
       <%= devise_error_messages! %>
 
       <div class="field">
-        <%= f.label :email %><br />
+        <%= f.label :email %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
       </div>
 


### PR DESCRIPTION
This adds basic styling to devise pages to match the overall look-and-feel of the welcome page.

Before:

<img width="581" alt="screen shot 2018-10-04 at 12 34 34 am" src="https://user-images.githubusercontent.com/293858/46453052-5074e180-c76d-11e8-979d-81673c0312af.png">

After:

<img width="1319" alt="screen shot 2018-10-04 at 1 04 39 am" src="https://user-images.githubusercontent.com/293858/46453843-9e8be400-c771-11e8-8af9-292b5689e6fc.png">
<img width="1240" alt="screen shot 2018-10-04 at 1 04 48 am" src="https://user-images.githubusercontent.com/293858/46453844-9e8be400-c771-11e8-8c0b-439bfbb017f0.png">
<img width="1025" alt="screen shot 2018-10-04 at 1 04 56 am" src="https://user-images.githubusercontent.com/293858/46453845-9f247a80-c771-11e8-86bb-422ae5b5a352.png">

