### PR TITLE
updated card.scss to make Terrastories logo work in card for Firefox

### DIFF
--- a/rails/app/assets/stylesheets/components/card.scss
+++ b/rails/app/assets/stylesheets/components/card.scss
@@ -75,7 +75,6 @@ $el-shadow: 0 1px 4px #bbb;
   .card--logo {
     margin: 0;
     padding: 1rem;
-    align-self: center;
 
     img {
       width: 100%;


### PR DESCRIPTION
Removed `align-self: center;` from `.card--logo`