### PR TITLE
[149] Fix Region Filter

### DIFF
--- a/rails/app/javascript/components/App.jsx
+++ b/rails/app/javascript/components/App.jsx
@@ -75,7 +75,7 @@ class App extends Component {
       case FILTER_CATEGORIES[0]: {
         // first category: region
         filteredStories = this.props.stories.filter(story => {
-          if (story.point.properties.region.toLowerCase() === item.toLowerCase()) {
+          if (story.point.properties.region && story.point.properties.region.toLowerCase() === item.toLowerCase()) {
             return story;
           }
         });


### PR DESCRIPTION
The filter for region was broken - nothing would filter when you selected one (with the imported data). The error was that story would return null, and toLowerCase() would error. This PR adds a check to make sure to only compare the region to points that have a non-null region. 