### PR TITLE
fixes admin user creation in the seeds

### DIFF
--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -45,8 +45,8 @@ Story.find_or_create_by(title: "Fa di Kwinti nengeb bi feti ku Matawai sembe",
                      point: flaming_forest,
                      permission_level: 1)
 
-User.where(email: 'admin@terrastories.com').first_or_create do |admin|
-  admin.password = 'password',
-  admin.password_confirmation = 'password',
+User.find_or_create_by!(email: 'admin@terrastories.com') do |admin|
+  admin.password = 'supersecretpassword'
+  admin.password_confirmation = 'supersecretpassword'
   admin.role = 1
 end


### PR DESCRIPTION
THE COMMAS! The commas turned the three statements into a single statement that returned an array:

    ["password", "password", 1]

So nothing got set on the attributes for the admin object and so the user was invalid because the password was too short.

This change removes the commas and updates the code to use `find_or_create_by!` as [documented in the Rails guide](https://guides.rubyonrails.org/v5.2/active_record_querying.html#find-or-build-a-new-object). The band-method version was chosen to that seeding the database would fail if it can not find the admin user or create a new valid one. Eventually this admin seed will need to change to not expect all installations to use the same email for the admin user.
