### PR TITLE
Add migration to fix coordinates

### DIFF
--- a/rails/db/migrate/20190308051200_convert_point_coordinates_again.rb
+++ b/rails/db/migrate/20190308051200_convert_point_coordinates_again.rb
@@ -1,0 +1,6 @@
+class ConvertPointCoordinatesAgain < ActiveRecord::Migration[5.2]
+  def change
+    change_column(:points, :lat, :decimal, precision: 10, scale: 6)
+    change_column(:points, :lng, :decimal, precision: 10, scale: 6)
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_27_215010) do
+ActiveRecord::Schema.define(version: 2019_03_08_051200) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -42,8 +42,8 @@ ActiveRecord::Schema.define(version: 2018_09_27_215010) do
 
   create_table "points", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
-    t.decimal "lng", precision: 15, scale: 13
-    t.decimal "lat", precision: 15, scale: 13
+    t.decimal "lng", precision: 10, scale: 6
+    t.decimal "lat", precision: 10, scale: 6
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "region"


### PR DESCRIPTION
Addressing this issue: https://github.com/rubyforgood/terrastories/issues/204

Added a migration to set the precision/scales to 10/6 for both `lat` and `lng` columns.

Thanks @robbkidd for thinking through this one! 👍 