### PR TITLE
#7: UI Story Filters

### DIFF
--- a/rails/.gitignore
+++ b/rails/.gitignore
@@ -31,3 +31,4 @@
 /node_modules
 yarn-debug.log*
 .yarn-integrity
+/media

--- a/rails/app/javascript/components/App.jsx
+++ b/rails/app/javascript/components/App.jsx
@@ -107,6 +107,21 @@ class App extends Component {
     (`Filtered Stories of ${category} ${item}:`, filteredStories);
   }
 
+  showMapPointStories = stories => {
+    this.clearFilteredStories();
+    let storyPointIds = stories.map(story => story.point_id);
+    let filteredStories = [];
+    filteredStories = this.props.stories.filter(story => {
+      if (storyPointIds.includes(story.point.id)) {
+        return story;
+      }
+    });
+    if (filteredStories) {
+      const filteredPoints = this.getPointsFromStories(filteredStories);
+      this.setState({stories: filteredStories, points: filteredPoints});
+    }
+  }
+
   render() {
     return (
       <div>
@@ -115,6 +130,7 @@ class App extends Component {
           pointCoords={this.state.pointCoords}
           mapboxAccessToken={this.props.mapbox_access_token}
           mapboxStyle={this.props.mapbox_style}
+          onMapPointClick={this.showMapPointStories}
         />
         <Card
           stories={this.state.stories}

--- a/rails/app/javascript/components/App.jsx
+++ b/rails/app/javascript/components/App.jsx
@@ -111,11 +111,7 @@ class App extends Component {
     this.clearFilteredStories();
     let storyPointIds = stories.map(story => story.point_id);
     let filteredStories = [];
-    filteredStories = this.props.stories.filter(story => {
-      if (storyPointIds.includes(story.point.id)) {
-        return story;
-      }
-    });
+    filteredStories = this.props.stories.filter(story => storyPointIds.includes(story.point.id));
     if (filteredStories) {
       const filteredPoints = this.getPointsFromStories(filteredStories);
       this.setState({stories: filteredStories, points: filteredPoints});

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -54,7 +54,8 @@ export default class Map extends Component {
 
            el.addEventListener('click', () =>
            {
-            this.props.onMapPointClick(marker.properties.stories);
+             this.props.onMapPointClick(marker.properties.stories);
+             this.map.panTo(marker.geometry.coordinates);
            }
          )
         });

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -54,8 +54,7 @@ export default class Map extends Component {
 
            el.addEventListener('click', () =>
            {
-             $(".story").hide();
-             $(".story." + el.id).show();
+            this.props.onMapPointClick(marker.properties.stories);
            }
          )
         });


### PR DESCRIPTION
Issue: https://github.com/rubyforgood/terrastories/issues/7

This PR adds a click event listener to each map marker that triggers the `showMapPointStories` function that belongs to `App`. The stories associated with each map point are passed up through the `Map` component and then all stories in `App` are filtered by comparing the `point_id` property found on the array stories assembled from the point marker to the `point.id` property found on the stories found in the top level component. 

### Future improvements 
_(pending completion of concurrent filter work)_
- Refactor the filter functionality to DRY out the code between the map point "filter" and the named filters (i.e. type of place, region, speaker name).