### PR TITLE
Issue #2 - Video does not stop playing when filters change

### DIFF
--- a/rails/app/javascript/components/StoryMedia.jsx
+++ b/rails/app/javascript/components/StoryMedia.jsx
@@ -19,6 +19,7 @@ class StoryMedia extends PureComponent {
         playsinline
         controls
         controlsList='nodownload'
+        key={file.url}
       >
         <source src={file.url} type={file.blob.content_type} />
       </video>


### PR DESCRIPTION
Issue #2 - React does know to rerender video element on url change because the `<video>` element itself isn't changing. Adding a key that includes the file url of the media ensures it gets update appropriately. 

Reference: https://stackoverflow.com/questions/41303012/updating-source-url-on-html5-video-with-react