### PR TITLE
Ensure serializers with story include id

### DIFF
--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -3,6 +3,7 @@ json.stories stories do |story|
   json.point story.point.point_geojson
   json.place story.point.place
   json.media story.media do |media|
+    json.id media.id
     json.url url_for(media)
     json.blob media.blob
   end

--- a/rails/app/views/stories/index.json.jbuilder
+++ b/rails/app/views/stories/index.json.jbuilder
@@ -3,6 +3,7 @@ json.stories @stories do |story|
   json.point story.point.point_geojson
   json.place story.point.place
   json.media story.media do |media|
+    json.id media.id
     json.url url_for(media)
     json.blob media.blob
   end


### PR DESCRIPTION
The `StoryMedia.jsx` component expects an `id` for media to be passed to ensure the video players get unique HTML `id`.