### PR TITLE
8 update map markers based on filters

### DIFF
--- a/rails/app/javascript/components/App.jsx
+++ b/rails/app/javascript/components/App.jsx
@@ -65,8 +65,11 @@ class App extends Component {
   }
 
   clearFilteredStories = () => {
+    const points = this.getPointsFromStories(this.props.stories);
+
     this.setState({
-      stories: this.props.stories
+      stories: this.props.stories,
+      points: points
     });
   }
 

--- a/rails/app/javascript/components/App.jsx
+++ b/rails/app/javascript/components/App.jsx
@@ -14,7 +14,8 @@ class App extends Component {
   }
 
   componentDidMount() {
-    this.getPointsFromStories(this.props.stories);
+    const points = this.getPointsFromStories(this.state.stories);
+    this.setState({points: points});
   }
 
   setPointCoords = pointCoords => {
@@ -25,7 +26,7 @@ class App extends Component {
     const points = stories.map(story => story.point);
     const pointObj = {};
     pointObj['features'] = points;
-    this.setState({points: pointObj});
+    return pointObj;
   }
 
   filterMap = () => {

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -7,19 +7,7 @@ export default class Map extends Component {
     mapboxgl.accessToken = this.props.mapboxAccessToken;
   }
 
-  state = {
-    points: this.props.points, // Used for points on map
-  }
-
   componentDidUpdate() {
-    if (this.props.pointCoords.length  > 0) {
-      if (this.map) {
-        this.map.flyTo({center: this.props.pointCoords, zoom: 14});
-      }
-    }
-  }
-
-  componentDidMount() {
     // @NOTE: MAKE SURE ARRAY IS [LONGITUDE, LATITUDE]
     const bounds = [
       [-60.80409032, 0.3332811], //southwest
@@ -33,6 +21,7 @@ export default class Map extends Component {
       zoom: 7.6,
       maxBounds: bounds
     });
+
     this.map.addControl(new mapboxgl.NavigationControl());
     if(this.props.points) {
       this.map.on('load', () => {
@@ -55,13 +44,21 @@ export default class Map extends Component {
            el.addEventListener('click', () =>
            {
              this.props.onMapPointClick(marker.properties.stories);
+             // this.map.setZoom({zoom: 1})
              this.map.panTo(marker.geometry.coordinates);
            }
          )
         });
       });
     }
+
+    if (this.props.pointCoords.length  > 0) {
+      if (this.map) {
+        this.map.flyTo({center: this.props.pointCoords, zoom: 14});
+      }
+    }
   }
+
   render() {
     return (
       <div ref={

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -7,7 +7,7 @@ export default class Map extends Component {
     mapboxgl.accessToken = this.props.mapboxAccessToken;
   }
 
-  componentDidUpdate() {
+  componentDidMount() {
     // @NOTE: MAKE SURE ARRAY IS [LONGITUDE, LATITUDE]
     const bounds = [
       [-60.80409032, 0.3332811], //southwest
@@ -22,35 +22,44 @@ export default class Map extends Component {
       maxBounds: bounds
     });
 
-    this.map.addControl(new mapboxgl.NavigationControl());
-    if(this.props.points) {
-      this.map.on('load', () => {
-        // just testing the passing in of the coords
-        this.props.points.features.forEach(marker => {
-          (marker.properties);
-           // create a HTML element for each feature
-           var el = document.createElement('div');
-           el.className = 'marker';
-           el.id = 'storypoint' + marker.id;
-           var popup = new mapboxgl
-             .Popup({ offset: 15 })
-             .setHTML('<h1>' + marker.properties.title + '</h1>' + '<h2>' + marker.properties.region + '</h2>')
-           // make a marker for each feature and add to the map
-           new mapboxgl.Marker(el)
-           .setLngLat(marker.geometry.coordinates)
-           .setPopup(popup) // sets a popup on this marker
-           .addTo(this.map);
+    this.map.on('load', () => {
+      this.updateMarkers();
+    });
 
-           el.addEventListener('click', () =>
-           {
-             this.props.onMapPointClick(marker.properties.stories);
-             // this.map.setZoom({zoom: 1})
-             this.map.panTo(marker.geometry.coordinates);
-           }
-         )
-        });
-      });
-    }
+    this.map.addControl(new mapboxgl.NavigationControl());
+  }
+
+  updateMarkers() {
+    this.props.points.features.forEach(marker => {
+      (marker.properties);
+       // create a HTML element for each feature
+       var el = document.createElement('div');
+       el.className = 'marker';
+       el.id = 'storypoint' + marker.id;
+       var popup = new mapboxgl
+         .Popup({ offset: 15 })
+         .setHTML('<h1>' + marker.properties.title + '</h1>' + '<h2>' + marker.properties.region + '</h2>')
+       // make a marker for each feature and add to the map
+       new mapboxgl.Marker(el)
+       .setLngLat(marker.geometry.coordinates)
+       .setPopup(popup) // sets a popup on this marker
+       .addTo(this.map);
+
+       el.addEventListener('click', () =>
+         {
+           this.props.onMapPointClick(marker.properties.stories);
+           this.map.panTo(marker.geometry.coordinates);
+         }
+       )
+    });
+  }
+
+  componentDidUpdate() {
+    [...document.querySelectorAll('.marker')].forEach(function(marker) {
+      marker.remove()
+    });
+
+    this.updateMarkers();
 
     if (this.props.pointCoords.length  > 0) {
       if (this.map) {

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -56,8 +56,12 @@ export default class Map extends Component {
 
   componentDidUpdate() {
     [...document.querySelectorAll('.marker')].forEach(function(marker) {
-      marker.remove()
+      marker.remove();
     });
+
+    [...document.querySelectorAll('.mapboxgl-popup')].forEach(function(popup) {
+      popup.remove();
+    })
 
     this.updateMarkers();
 


### PR DESCRIPTION
Addresses Issue #8 

The `Map` component was rendering the markers in `componentDidMount()`, which meant that even when the `points` props changed, the markers weren't being re-rendered. I moved the marker rendering into its own method, `updateMarkers()`, which gets called in `componentDidUpdate()`. 
Also, marker popups get cleared whenever the filters are adjusted.