### PR TITLE
Fix video playback being truncated

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -14,6 +14,7 @@ http {
     }
     location / {
       client_max_body_size 500M;
+      proxy_http_version 1.1;
       proxy_pass http://rails:3000/;
       proxy_set_header Host            $host:3000;
       proxy_set_header X-Forwarded-For $remote_addr;

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -14,6 +14,7 @@ http {
     }
     location / {
       client_max_body_size 500M;
+      proxy_http_version 1.1;
       proxy_pass http://rails:3000/;
       proxy_set_header Host            $host:NGINX_PORT;
       proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
Issue: https://github.com/rubyforgood/terrastories/issues/1

Apparently nginx defaults would truncate the video. More details in this
SO answer https://stackoverflow.com/a/53410174