### PR TITLE
Fixes console warning

### DIFF
--- a/rails/app/javascript/components/StoryMedia.jsx
+++ b/rails/app/javascript/components/StoryMedia.jsx
@@ -25,7 +25,7 @@ class StoryMedia extends PureComponent {
         id={`video-player${file.blob.id}`}
         className="video-player"
         height={explicitVideoHeight}
-        playsinline
+        playsInline
         controls
         controlsList='nodownload'
         key={file.url}


### PR DESCRIPTION
Fixes #50 

Speaking with @rudokemper, the other warnings in console related to mapbox, tileserver and sprites are benign. This one with `playsInline` vs `playsinline` was something in the terrastories rails codebase itself and an easy fix.