### PR TITLE
Increase timeout to 10 minutes

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -16,6 +16,7 @@ http {
       client_max_body_size 500M;
       proxy_http_version 1.1;
       proxy_pass http://rails:3000/;
+      proxy_read_timeout 600;
       proxy_set_header Host            $host:3000;
       proxy_set_header X-Forwarded-For $remote_addr;
     }

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -16,6 +16,7 @@ http {
       client_max_body_size 500M;
       proxy_http_version 1.1;
       proxy_pass http://rails:3000/;
+      proxy_read_timeout 600;
       proxy_set_header Host            $host:NGINX_PORT;
       proxy_set_header X-Forwarded-For $remote_addr;
     }


### PR DESCRIPTION
Issue: https://github.com/rubyforgood/terrastories/issues/16

The default timeout is 60 seconds, which would affect some of the CSV
uploads. I tried restricting the timeout to the `import_csv` routes only
but nginx rule inheritance is a little complicated, so I'm taking the
easy way out by increasing the timeout globally.

While this probably won't be a problem for the NUC local wifi
deployments, this timeout should be restricted to `import_csv` routes if
deployed to the cloud, because it would be easy to DOS the server with a
couple long running requests.